### PR TITLE
[FIX] using utcnow in _set_calendar_last_notif_ack

### DIFF
--- a/addons/calendar/calendar.py
+++ b/addons/calendar/calendar.py
@@ -315,7 +315,7 @@ class res_partner(osv.Model):
 
     def _set_calendar_last_notif_ack(self, cr, uid, context=None):
         partner = self.pool['res.users'].browse(cr, uid, uid, context=context).partner_id
-        self.write(cr, uid, partner.id, {'calendar_last_notif_ack': datetime.now()}, context=context)
+        self.write(cr, uid, partner.id, {'calendar_last_notif_ack': datetime.utcnow()}, context=context)
         return
 
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Using datetime.now() was causing improper behavior of the visual notification popups of the calendar module

Current behavior before PR:
Calendar popups was not showing anymore after one of them had the "Ok" button pressed, until many hours later.

Desired behavior after PR is merged:
Calendar popups works correctly as planned

Impacted versions:
- 8.0
